### PR TITLE
GDL90 Device emulation for Garmin Pilot

### DIFF
--- a/main/flarm-nmea.go
+++ b/main/flarm-nmea.go
@@ -428,7 +428,7 @@ func makePGRMZString() string {
 	return msg
 }
 
-func makeAHRSLevilReport() {
+func sendAHRSLevilReport() {
 	if !globalStatus.IMUConnected || !isAHRSValid() {
 		return
 	}

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -851,6 +851,8 @@ func sendAllStatusInfo() {
 
 	sendStratux(makeStratuxStatus(), timeout, 1)
 	sendGDL90(makeFFIDMessage(), timeout, 1)
+	// Geo ownership is on a slower update path then ownership
+	sendOwnshipGeometricAltitudeReport()
 }
 
 
@@ -858,7 +860,7 @@ func sendTrafficReport() {
 	// --- debug code: traffic demo ---
 	// Uncomment and compile to display large number of artificial traffic targets
 	
-		numTargets := uint32(36)
+		numTargets := uint32(10)
 		hexCode := uint32(0xFF0000)
 
 		for i := uint32(0); i < numTargets; i++ {
@@ -868,7 +870,6 @@ func sendTrafficReport() {
 			spd := float64(50 + ((i*23)%13)*37)
 
 			updateDemoTraffic(i|hexCode, tail, alt, spd, hdg, true)
-
 		}
 	
 
@@ -882,9 +883,7 @@ func sendAllHeartbeatInfo() {
 }
 
 func sendAllOwnshipInfo() {
-	//log.Printf("Sending ownship info")
 	sendOwnshipReport()
-	sendOwnshipGeometricAltitudeReport()
 }
 
 func sendAllFLARMInfo() {
@@ -916,6 +915,7 @@ func heartBeatSender() {
 	trafficTimer := time.NewTicker(trafficRate)
 	infoTimer := time.NewTicker(infoRate)
 	ledBlinking := false
+
 	for {
 		select {
 		case <- infoTimer.C:
@@ -951,11 +951,13 @@ func heartBeatSender() {
 				lastState = globalSettings.Stratus_Enabled
 				
 				if globalSettings.Stratus_Enabled {
-					ownerRate = STRATUX_OWNER_RATE
+					ownerRate = STRATUS_OWNER_RATE
 					trafficRate = STRATUS_TRAFFIC_RATE
+					infoRate = STRATUS_INFO_RATE
 				} else {
 					ownerRate = STRATUX_OWNER_RATE
 					trafficRate = STRATUX_TRAFFIC_RATE
+					infoRate = STRATUX_INFO_RATE
 				}
 
 				ownerTimer = time.NewTicker(ownerRate)

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -849,7 +849,7 @@ func stratusInfoSender() {
 	for {
 		<-timer.C
 		if globalSettings.Stratus_Enabled {
-			sendGDL90(makeStratusStatus(), time.Second, 1)
+			sendStratus(makeStratusStatus(), time.Second, 1)
 		}
 	}
 }

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -461,12 +461,11 @@ func sendOwnshipReport() bool {
 	timeout := STRATUX_OWNER_RATE
 	if globalSettings.Stratus_Enabled {
 		timeout = STRATUS_OWNER_RATE
+	} else {
+		sendXPlane(createXPlaneGpsMsg(lat, lon, mySituation.GPSAltitudeMSL, groundTrack, float32(gdSpeed)), timeout, 0)
 	}
 
-	sendGDL90(prepareMessage(msg), timeout, -2)
-	//TODO: might not bother sending XPlane when stratus emulation is on
-	sendXPlane(createXPlaneGpsMsg(lat, lon, mySituation.GPSAltitudeMSL, groundTrack, float32(gdSpeed)), timeout, 0)
-
+	sendGDL90(prepareMessage(msg), timeout, 1)
 	return true
 }
 

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -849,7 +849,7 @@ func stratusInfoSender() {
 	for {
 		<-timer.C
 		if globalSettings.Stratus_Enabled {
-			sendStratus(makeStratusStatus(), time.Second, 1)
+			sendGDL90(makeStratusStatus(), time.Second, 1)
 		}
 	}
 }

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -115,7 +115,7 @@ const (
 	// 5Hz seems to be the minimum to keep traffic from blinking out when emulating stratus
 	STRATUS_TRAFFIC_RATE = 200 * time.Millisecond
 	STRATUX_AHRS_RATE    = 50 * time.Millisecond
-	STRATUS_AHRS_RATE    = 100 * time.Millisecond
+	STRATUS_AHRS_RATE    = STRATUX_AHRS_RATE //100 * time.Millisecond
 )
 
 var logFileHandle *os.File
@@ -846,8 +846,9 @@ func sendAllStatusInfo() {
 	
 	if globalSettings.Stratus_Enabled {
 		sendGDL90(makeStratusStatus(), timeout, 1)
+	}else {
+		sendGDL90(makeStratuxStatus(), timeout, 1) // see if this breaks the web UI
 	}
-	sendGDL90(makeStratuxStatus(), timeout, 1)
 	sendGDL90(makeFFIDMessage(), timeout, 1)
 	// Geo ownership is on a slower update path then ownership
 	sendOwnshipGeometricAltitudeReport()
@@ -857,7 +858,7 @@ func sendAllStatusInfo() {
 func sendTrafficReport() {
 	// --- debug code: traffic demo ---
 	// Uncomment and compile to display large number of artificial traffic targets
-	
+	/*
 		numTargets := uint32(10)
 		hexCode := uint32(0xFF0000)
 
@@ -869,7 +870,7 @@ func sendTrafficReport() {
 
 			updateDemoTraffic(i|hexCode, tail, alt, spd, hdg, true)
 		}
-	
+	*/
 
 	// ---end traffic demo code ---
 	sendTrafficUpdates()

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -843,14 +843,19 @@ func blinkStatusLED() {
 	}
 }
 
+// TODO: Temp code for messing around with this it suddenly stopped working
+func stratusInfoSender() {
+	timer := time.NewTicker(800 * time.Millisecond)
+	for {
+		<-timer.C
+		if globalSettings.Stratus_Enabled {
+			sendStratus(makeStratusStatus(), time.Second, 1)
+		}
+	}
+}
+
 func sendAllStatusInfo() {
 	timeout := STRATUX_INFO_RATE
-	
-	if globalSettings.Stratus_Enabled {
-		timeout = STRATUS_INFO_RATE
-		sendStratus(makeStratusStatus(), timeout, 1)
-	}
-
 	sendStratux(makeStratuxStatus(), timeout, 1)
 	sendGDL90(makeFFIDMessage(), timeout, 1)
 	// Geo ownership is on a slower update path then ownership
@@ -1859,7 +1864,9 @@ func main() {
 
 	// Start the heartbeat message loop in the background, once per second.
 	go heartBeatSender()
-
+	
+	// added this because the HR is gone
+	go stratusInfoSender()
 	// Initialize the (out) network handler.
 	initNetwork()
 

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -116,6 +116,8 @@ const (
 	STRATUX_TRAFFIC_RATE = DEFAULT_MSG_RATE
 	// 5Hz seems to be the minimum to keep traffic from blinking out when emulating stratus
 	STRATUS_TRAFFIC_RATE = 200 * time.Millisecond
+	STRATUX_AHRS_RATE    = 50 * time.Millisecond
+	STRATUS_AHRS_RATE    = 100 * time.Millisecond
 )
 
 var logFileHandle *os.File

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -897,7 +897,7 @@ func heartBeatSender() {
 	trafficRate := STRATUX_TRAFFIC_RATE
 
 	if globalSettings.Stratus_Enabled {
-		ownerRate = STRATUX_OWNER_RATE
+		ownerRate = STRATUS_OWNER_RATE
 		trafficRate = STRATUS_TRAFFIC_RATE
 	}
 	
@@ -931,7 +931,6 @@ func heartBeatSender() {
 			sendAllHeartbeatInfo()
 			updateStatus()
 			sendAllStatusInfo()
-			//TODO: could dissable flarm sending when in Stratus mode
 			sendAllFLARMInfo()
 		case <-timerMessageStats.C:
 			// Save a bit of CPU by not pruning the message log every 1 second.

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -519,11 +519,11 @@ func makeStratusStatus() []byte {
 	copy(msg[3:], thisVers)
 	msg[18] = 0
 
-	// temp := fmt.Sprintf("%.1f C", globalStatus.CPUTemp)
-	// copy(msg[19:], temp)
-	for i := 19; i <= 23; i++ {
-		msg[i] = 'A'
-	}
+	temp := fmt.Sprintf("%.1f C", globalStatus.CPUTemp)
+	copy(msg[19:], temp)
+	// for i := 19; i <= 23; i++ {
+	// 	msg[i] = 'A'
+	// }
 	msg[24] = 0x0
 
 	// battery % 0-100 write the temprature for now

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -109,7 +109,7 @@ const (
 	
 	// Transimition rates for messages
 	DEFAULT_MSG_RATE     = time.Second  // 1Hz
-	STRATUX_INFO_RATE	 = DEFAULT_MSG_RATE
+	STRATUX_INFO_RATE    = DEFAULT_MSG_RATE
 	STRATUS_INFO_RATE    = 500 * time.Millisecond
 	STRATUX_OWNER_RATE   = DEFAULT_MSG_RATE
 	STRATUS_OWNER_RATE   = 100 * time.Millisecond // 10hz (need to test with more settings)
@@ -517,8 +517,11 @@ func makeStratusStatus() []byte {
 	copy(msg[3:], thisVers)
 	msg[18] = 0
 
-	temp := fmt.Sprintf("%.1f C", globalStatus.CPUTemp)
-	copy(msg[19:], temp)
+	// temp := fmt.Sprintf("%.1f C", globalStatus.CPUTemp)
+	// copy(msg[19:], temp)
+	for i := 19; i <= 23; i++ {
+		msg[i] = 'A'
+	}
 	msg[24] = 0x0
 
 	// battery % 0-100 write the temprature for now

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -747,7 +747,7 @@ func makeFFIDMessage() []byte {
 	// Just for emulation correctness
 	if globalSettings.Stratus_Enabled {
 		devShortName = "Stratus"
-		devLongName = fmt.Sprintf("Stratus3%s",stratuxBuild)
+		devLongName = fmt.Sprintf("Stratus 3 %s",stratuxBuild)
 	}
 
 	if len(devShortName) > 8 {

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -878,7 +878,9 @@ func sendTrafficReport() {
 
 func sendAllHeartbeatInfo() {
 	sendGDL90(makeHeartbeat(), DEFAULT_MSG_RATE, -20) // Highest priority, always needs to be send because we use it to detect when a client becomes available
-	sendGDL90(makeStratuxHeartbeat(), DEFAULT_MSG_RATE, 0)
+	if !globalSettings.Stratus_Enabled {
+		sendGDL90(makeStratuxHeartbeat(), DEFAULT_MSG_RATE, 0)
+	}
 }
 
 func sendAllOwnshipInfo() {

--- a/main/gps.go
+++ b/main/gps.go
@@ -1897,9 +1897,9 @@ func gpsSerialReader() {
 }
 
 func sendAHRSSimReport() {
-	// if gloabalSettings.Stratus_Enabled {
-	// 	return
-	// }
+	if globalSettings.Stratus_Enabled {
+		return
+	}
 
 	msg := createXPlaneAttitudeMsg(float32(mySituation.AHRSGyroHeading), float32(mySituation.AHRSPitch), float32(mySituation.AHRSRoll))
 	sendXPlane(msg, 100 * time.Millisecond, 1)

--- a/main/gps.go
+++ b/main/gps.go
@@ -1966,7 +1966,8 @@ func sendFFAHRSMessage() {
 
 func sendAHRSGDL90Report() {
 	
-	if gloabalSettings.Stratus_Enabled {
+	// TODO: Decide if we want to send both
+	if globalSettings.Stratus_Enabled {
 		return
 	}
 

--- a/main/gps.go
+++ b/main/gps.go
@@ -1896,20 +1896,24 @@ func gpsSerialReader() {
 	return
 }
 
-func makeAHRSSimReport() {
+func sendAHRSSimReport() {
+	// if gloabalSettings.Stratus_Enabled {
+	// 	return
+	// }
+
 	msg := createXPlaneAttitudeMsg(float32(mySituation.AHRSGyroHeading), float32(mySituation.AHRSPitch), float32(mySituation.AHRSRoll))
 	sendXPlane(msg, 100 * time.Millisecond, 1)
 }
 
 /*
 
-	ForeFlight "AHRS Message".
+	ForeFlight/Stratus "AHRS Message".
 
 	Sends AHRS information to ForeFlight.
 
 */
 
-func makeFFAHRSMessage() {
+func sendFFAHRSMessage() {
 	msg := make([]byte, 12)
 	msg[0] = 0x65 // Message type "ForeFlight".
 	msg[1] = 0x01 // AHRS message identifier.
@@ -1920,13 +1924,20 @@ func makeFFAHRSMessage() {
 	hdg := uint16(0xFFFF)
 	ias := uint16(0xFFFF)
 	tas := uint16(0xFFFF)
-
+	// TODO: This should use a RW lock
 	if isAHRSValid() {
 		if !isAHRSInvalidValue(mySituation.AHRSPitch) {
 			pitch = common.RoundToInt16(mySituation.AHRSPitch * 10)
 		}
 		if !isAHRSInvalidValue(mySituation.AHRSRoll) {
 			roll = common.RoundToInt16(mySituation.AHRSRoll * 10)
+		}
+		if !isAHRSInvalidValue(mySituation.AHRSGyroHeading) {
+			hdg = uint16(common.RoundToInt16(mySituation.AHRSGyroHeading * 10))
+		}
+		// TODO: not sure if using GS for TAS is a good idea, better than nothing?
+		if isGPSGroundTrackValid() {
+			tas = uint16(mySituation.GPSGroundSpeed + 0.5)
 		}
 	}
 
@@ -1947,26 +1958,18 @@ func makeFFAHRSMessage() {
 	msg[9] = byte(ias & 0xFF)
 
 	// True Airspeed.
-	msg[10] = byte((tas >> 8) & 0xFF)
-	msg[11] = byte(tas & 0xFF)
+	msg[10] = byte((tas & 0xFF0) >> 4)
+	msg[11] = byte((tas & 0x00F) << 4)
 
-	sendMsg(prepareMessage(msg), NETWORK_AHRS_GDL90, 200 * time.Millisecond, 3)
+	sendMsg(prepareMessage(msg), NETWORK_AHRS_GDL90,  100 * time.Millisecond, 3)
 }
 
-/*
-	ffAttitudeSender()
-	 Send AHRS message in FF format every 200ms.
-*/
-
-func ffAttitudeSender() {
-	ticker := time.NewTicker(200 * time.Millisecond)
-	for {
-		<-ticker.C
-		makeFFAHRSMessage()
+func sendAHRSGDL90Report() {
+	
+	if gloabalSettings.Stratus_Enabled {
+		return
 	}
-}
 
-func makeAHRSGDL90Report() {
 	msg := make([]byte, 24)
 	msg[0] = 0x4c
 	msg[1] = 0x45
@@ -2079,9 +2082,10 @@ func gpsAttitudeSender() {
 					mySituation.AHRSGyroHeading = float64(mySituation.GPSTrueCourse)
 					mySituation.AHRSLastAttitudeTime = stratuxClock.Time
 
-					makeAHRSGDL90Report()
-					makeAHRSSimReport()
-					makeAHRSLevilReport()
+					sendAHRSGDL90Report()
+					sendAHRSSimReport()
+					sendAHRSLevilReport()
+					sendFFAHRSMessage()
 				}
 				mySituation.muGPSPerformance.Unlock()
 			}
@@ -2174,7 +2178,6 @@ func pollGPS() {
 	readyToInitGPS = true //TODO: Implement more robust method (channel control) to kill zombie serial readers
 	timer := time.NewTicker(4 * time.Second)
 	go gpsAttitudeSender()
-	go ffAttitudeSender()
 	for {
 		<-timer.C
 		// GPS enabled, was not connected previously?

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -354,6 +354,14 @@ func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
 						globalSettings.AIS_Enabled = val.(bool)
 					case "Ping_Enabled":
 						globalSettings.Ping_Enabled = val.(bool)
+					case "Stratus_Enabled":
+						globalSettings.Stratus_Enabled = val.(bool)
+						// change address accordingly
+						ipStr := "1923168.10.1"
+						if globalSettings.Stratus_Enabled {
+							ipStr = "10.29.39.1"
+						}
+						setWifiIPAddress(ipStr)
 					case "GPS_Enabled":
 						globalSettings.GPS_Enabled = val.(bool)
 					case "IMU_Sensor_Enabled":
@@ -572,7 +580,7 @@ func handleDeleteAHRSLogFiles(w http.ResponseWriter, r *http.Request) {
 
 func handleDevelModeToggle(w http.ResponseWriter, r *http.Request) {
 	log.Printf("handleDevelModeToggle called!!!\n")
-	globalSettings.DeveloperMode = true
+	globalSettings.DeveloperMode = !globalSettings.DeveloperMode
 	saveSettings()
 }
 

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -357,7 +357,7 @@ func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
 					case "Stratus_Enabled":
 						globalSettings.Stratus_Enabled = val.(bool)
 						// change address accordingly
-						ipStr := "1923168.10.1"
+						ipStr := "192.168.10.1"
 						if globalSettings.Stratus_Enabled {
 							ipStr = "10.29.39.1"
 						}

--- a/main/network.go
+++ b/main/network.go
@@ -440,15 +440,19 @@ func connectionWriter(connection connection) {
 	}
 }
 
-
 func sendMsg(msg []byte, msgType uint8, maxAge time.Duration, priority int32) {
-	if (msgType & NETWORK_GDL90_STANDARD) != 0 {
+
+	// TODO: this is probably not needed but for completeness.
+	if (msgType & NETWORK_STRATUS) != 0 && !globalSettings.Stratus_Enabled {
+		return
+	}
+
+	if (msgType & NETWORK_GDL90_STANDARD | NETWORK_STRATUX | NETWORK_STRATUS) != 0 {
 		// It's a GDL90 message - do ui broadcast.
 		networkGDL90Chan <- msg
 	}
 
 	// Don't send Stratux specific messages when emulating Stratus
-	// TODO: this is probably not needed but for completeness.
 	if (msgType & NETWORK_STRATUX) != 0 && globalSettings.Stratus_Enabled {
 		return
 	}

--- a/main/network.go
+++ b/main/network.go
@@ -36,13 +36,11 @@ var netMutex *sync.Mutex              // netMutex needs to be locked before acce
 var totalNetworkMessagesSent uint32
 
 const (
-	NETWORK_GDL90_STANDARD = 0x1
-	NETWORK_AHRS_FFSIM     = 0x2
-	NETWORK_AHRS_GDL90     = 0x4
-	NETWORK_FLARM_NMEA     = 0x8
-	NETWORK_POSITION_FFSIM = 0x10
-	NETWORK_STRATUS        = 0x20
-	NETWORK_STRATUX        = 0x40
+	NETWORK_GDL90_STANDARD = 1
+	NETWORK_AHRS_FFSIM     = 2
+	NETWORK_AHRS_GDL90     = 4
+	NETWORK_FLARM_NMEA     = 8
+	NETWORK_POSITION_FFSIM = 16
 	dhcp_lease_file        = "/var/lib/misc/dnsmasq.leases"
 	dhcp_lease_dir         = "/var/lib/misc/"
 	extra_hosts_file       = "/etc/stratux-static-hosts.conf"
@@ -442,19 +440,9 @@ func connectionWriter(connection connection) {
 
 func sendMsg(msg []byte, msgType uint8, maxAge time.Duration, priority int32) {
 
-	// TODO: this is probably not needed but for completeness.
-	if (msgType & NETWORK_STRATUS) != 0 && !globalSettings.Stratus_Enabled {
-		return
-	}
-
-	if (msgType & (NETWORK_GDL90_STANDARD | NETWORK_STRATUX | NETWORK_STRATUS)) != 0 {
+	if (msgType & NETWORK_GDL90_STANDARD) != 0 {
 		// It's a GDL90 message - do ui broadcast.
 		networkGDL90Chan <- msg
-	}
-
-	// Don't send Stratux specific messages when emulating Stratus
-	if (msgType & NETWORK_STRATUX) != 0 && globalSettings.Stratus_Enabled {
-		return
 	}
 
 	netMutex.Lock()
@@ -468,15 +456,6 @@ func sendMsg(msg []byte, msgType uint8, maxAge time.Duration, priority int32) {
 		}
 		conn.MessageQueue().Put(priority, maxAge, msg)
 	}
-}
-
-
-func sendStratux(msg []byte, maxAge time.Duration, priority int32) {
-	sendMsg(msg, NETWORK_STRATUX, maxAge, priority)
-}
-
-func sendStratus(msg []byte, maxAge time.Duration, priority int32) {
-	sendMsg(msg, NETWORK_STRATUS, maxAge, priority)
 }
 
 func sendGDL90(msg []byte, maxAge time.Duration, priority int32) {

--- a/main/network.go
+++ b/main/network.go
@@ -447,7 +447,7 @@ func sendMsg(msg []byte, msgType uint8, maxAge time.Duration, priority int32) {
 		return
 	}
 
-	if (msgType & NETWORK_GDL90_STANDARD | NETWORK_STRATUX | NETWORK_STRATUS) != 0 {
+	if (msgType & (NETWORK_GDL90_STANDARD | NETWORK_STRATUX | NETWORK_STRATUS)) != 0 {
 		// It's a GDL90 message - do ui broadcast.
 		networkGDL90Chan <- msg
 	}

--- a/main/networksettings.go
+++ b/main/networksettings.go
@@ -146,7 +146,11 @@ func applyNetworkSettings(force bool, onlyWriteFiles bool) {
 	ipAddr := globalSettings.WiFiIPAddress
 	log.Printf("Applying new network settings for IP %s", ipAddr);
 	if ipAddr == "" {
-		ipAddr = "192.168.10.1"
+		if globalSettings.Stratus_Enabled == true {
+			ipAddr = "10.29.39.1"
+		} else {
+			ipAddr = "192.168.10.1"
+		}
 	}
 	ipParts := strings.Split(ipAddr, ".")
 	

--- a/main/sensors.go
+++ b/main/sensors.go
@@ -364,9 +364,11 @@ func sensorAttitudeSender() {
 			}
 			mySituation.muAttitude.Unlock()
 
-			makeAHRSGDL90Report() // Send whether or not valid - the function will invalidate the values as appropriate
-			makeAHRSSimReport()
-			makeAHRSLevilReport()
+			// TODO: decide if we want to only send FFAHRS when emulating FF
+			sendFFAHRSMessage()
+			sendAHRSGDL90Report() // Send whether or not valid - the function will invalidate the values as appropriate
+			sendAHRSSimReport()
+			sendAHRSLevilReport()
 
 			// Send to AHRS debugging server.
 			if ahrswebListener != nil {

--- a/main/traffic.go
+++ b/main/traffic.go
@@ -392,9 +392,11 @@ func sendTrafficUpdates() {
 					trafficCallsign = fmt.Sprintf("%X_%d", ti.Icao_addr, ti.Squawk)
 				}
 
-				// send traffic message to X-Plane
-				// TODO decide if we send XPlane and FLARM when in Stratus mode
-				sendXPlane(createXPlaneTrafficMsg(ti.Icao_addr, ti.Lat, ti.Lng, ti.Alt, uint32(ti.Speed), int32(ti.Vvel), ti.OnGround, uint32(ti.Track), trafficCallsign), timeout, priority)
+				if !globalSettings.Stratus_Enabled {
+					// send traffic message to X-Plane
+					sendXPlane(createXPlaneTrafficMsg(ti.Icao_addr, ti.Lat, ti.Lng, ti.Alt, uint32(ti.Speed), int32(ti.Vvel), ti.OnGround, uint32(ti.Track), trafficCallsign), timeout, priority)
+				}
+				// TODO decide if we sendFLARM when in Stratus mode
 				if validFLARM {
 					sendNetFLARM(thisMsgFLARM, timeout, priority)
 				}

--- a/notes/app-vendor-integration.md
+++ b/notes/app-vendor-integration.md
@@ -157,6 +157,7 @@ Stratux makes available a webserver to retrieve statistics which may be useful t
   "UAT_Enabled": true,
   "ES_Enabled": false,
   "Ping_Enabled": false,
+  "Stratus_Enabled": false,
   "GPS_Enabled": true,
   "BMP_Sensor_Enabled": true,
   "IMU_Sensor_Enabled": true,

--- a/notes/protocol.txt
+++ b/notes/protocol.txt
@@ -4,7 +4,7 @@ Not queueable:
 	makeHeartbeat()							[each second]
 	makeInitializationMessage()				[each second]
 	makeTrafficReport()						[re-generated each second depending on target status]
-	makeFFAHRSSimReport()					[short useful life]
-	makeAHRSGDL90Report()					[short useful life]
+	sendFFAHRSSimReport()					[short useful life]
+	sendAHRSGDL90Report()					[short useful life]
 Queueable:
 	relayMessage()							[all uplink messages]

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -260,7 +260,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 
 	$scope.$parent.helppage = 'plates/settings-help.html';
 
-	var toggles = ['UAT_Enabled', 'ES_Enabled', 'OGN_Enabled', 'AIS_Enabled', 'Ping_Enabled', 'GPS_Enabled', 'IMU_Sensor_Enabled',
+	var toggles = ['UAT_Enabled', 'ES_Enabled', 'OGN_Enabled', 'AIS_Enabled', 'Ping_Enabled', 'Stratus_Enabled', 'GPS_Enabled', 'IMU_Sensor_Enabled',
 		'BMP_Sensor_Enabled', 'DisplayTrafficSource', 'DEBUG', 'ReplayLog', 'AHRSLog', 'PersistentLogging', 'GDL90MSLAlt_Enabled', 'EstimateBearinglessDist', 'DarkMode'];
 
 	var settings = {};
@@ -297,6 +297,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 		$scope.OGN_Enabled = settings.OGN_Enabled;
 		$scope.AIS_Enabled = settings.AIS_Enabled;
 		$scope.Ping_Enabled = settings.Ping_Enabled;
+		$scope.Stratus_Enabled = settings.Stratus_Enabled;
 		$scope.GPS_Enabled = settings.GPS_Enabled;
 
 		$scope.IMU_Sensor_Enabled = settings.IMU_Sensor_Enabled;

--- a/web/plates/js/status.js
+++ b/web/plates/js/status.js
@@ -196,6 +196,8 @@ function StatusCtrl($rootScope, $scope, $state, $http, $interval, craftService) 
 				$scope.visible_uat = true;
 				$scope.visible_es = true;
 			}
+
+			$scope.Stratus_Enabled = settings.Stratus_Enabled;
 			$scope.visible_gps = settings.GPS_Enabled;
 		}, function (response) {
 			// nop

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -377,7 +377,7 @@
                         </div>
                     </div>
                     <div class="form-group reset-flow">
-                        <label class="control-label col-xs-5">Stratus 3 Emulation</label>
+                        <label class="control-label col-xs-5">Stratus 3 Emulation for GP (Experimental)</label>
                         <div class="col-xs-7">
                             <ui-switch ng-model='Stratus_Enabled' settings-change></ui-switch>
                         </div>

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -376,7 +376,12 @@
                             <ui-switch ng-model='Ping_Enabled' settings-change></ui-switch>
                         </div>
                     </div>
-
+                    <div class="form-group reset-flow">
+                        <label class="control-label col-xs-5">Stratus 3 Emulation</label>
+                        <div class="col-xs-7">
+                            <ui-switch ng-model='Stratus_Enabled' settings-change></ui-switch>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This is a first just at getting the Stratux to work with Garmin Pilot using GDL90 protocols that are "supported" by Garmin Pilot.  
-> Added toggle in the UI settings to turn the feature on.
-> Added emulation support so that GP sees the device as it should

Compared to using the Flight Sim link this has the following advantages for GP
1. Synthetic Vision is actually usable (the FS link has huge latency with GP)
2. Hopefully FIS-B weather data (untested but should work)
3. More robust traffic data.  When using the FS link, all traffic can just vanish for a few seconds before redrawing.  This seems to be better right now.

One major bummer is that GP is using the FF AHRS data packet and not the GDL90 standard packet.  You do not get any advanced attitude data like slip/skid, etc.