### PR TITLE
Add switch for limiting traffic

### DIFF
--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -1303,6 +1303,7 @@ type settings struct {
 	BMP_Sensor_Enabled   bool
 	IMU_Sensor_Enabled   bool
 	Stratus_Enabled      bool
+	LimitTraffic_Enabled bool
 	FakeTrafficCount     int
 	NetworkOutputs       []networkConnection
 	SerialOutputs        map[string]serialConnection
@@ -1337,7 +1338,6 @@ type settings struct {
 	EstimateBearinglessDist bool
 	RadarLimits          int
 	RadarRange           int
-	LimitTraffic_Enabled bool
 
 	OGNAddr              string
 	OGNAddrType          int

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -467,7 +467,7 @@ func sendOwnshipReport() bool {
 		sendXPlane(createXPlaneGpsMsg(lat, lon, mySituation.GPSAltitudeMSL, groundTrack, float32(gdSpeed)), timeout, 0)
 	}
 
-	sendGDL90(prepareMessage(msg), timeout, 1)
+	sendGDL90(prepareMessage(msg), timeout, -1)
 	return true
 }
 

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -1337,6 +1337,7 @@ type settings struct {
 	EstimateBearinglessDist bool
 	RadarLimits          int
 	RadarRange           int
+	LimitTraffic_Enabled bool
 
 	OGNAddr              string
 	OGNAddrType          int
@@ -1444,6 +1445,7 @@ func defaultSettings() {
 	globalSettings.RadarLimits = 2000
 	globalSettings.RadarRange = 10
 	globalSettings.AltitudeOffset = 0
+	globalSettings.LimitTraffic_Enabled = false
 
 	globalSettings.PWMDutyMin = 0
 }

--- a/main/gps.go
+++ b/main/gps.go
@@ -2045,7 +2045,7 @@ func sendAHRSGDL90Report() {
 	msg[19] = byte(palt & 0xFF)
 
 	// Vertical Speed
-		msg[20] = byte((vs >> 8) & 0xFF)
+	msg[20] = byte((vs >> 8) & 0xFF)
 	msg[21] = byte(vs & 0xFF)
 
 	// Reserved

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -408,6 +408,8 @@ func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
 					case "RadarRange":
 						globalSettings.RadarRange = int(val.(float64))
 						radarUpdate.SendJSON(globalSettings)
+					case "LimitTraffic_Enabled":
+						globalSettings.LimitTraffic_Enabled = val.(bool)
 					case "Baud":
 						if globalSettings.SerialOutputs != nil {
 							for dev, serialOut := range globalSettings.SerialOutputs {

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -362,6 +362,8 @@ func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
 							ipStr = "10.29.39.1"
 						}
 						setWifiIPAddress(ipStr)
+					case "LimitTraffic_Enabled":
+						globalSettings.LimitTraffic_Enabled = val.(bool)
 					case "FakeTrafficCount":
 						globalSettings.FakeTrafficCount = int(val.(float64))
 					case "GPS_Enabled":
@@ -408,8 +410,6 @@ func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
 					case "RadarRange":
 						globalSettings.RadarRange = int(val.(float64))
 						radarUpdate.SendJSON(globalSettings)
-					case "LimitTraffic_Enabled":
-						globalSettings.LimitTraffic_Enabled = val.(bool)
 					case "Baud":
 						if globalSettings.SerialOutputs != nil {
 							for dev, serialOut := range globalSettings.SerialOutputs {

--- a/main/traffic.go
+++ b/main/traffic.go
@@ -367,6 +367,12 @@ func sendTrafficUpdates() {
 			//TODO: Coast old traffic? Need to determine how FF, WingX, etc deal with stale targets.
 			logTraffic(ti) // only add to the SQLite log if it's not stale
 
+			// BUGBUG: Garmin Pilot can crash when more than 70 targets while using Synthetic Vision
+			// To work around this, until they fix it, restrict the size of targets to the radar range in the web UI
+			if globalSettings.LimitTraffic_Enabled {
+				shouldIgnore |= ti.Distance > float64(globalSettings.RadarRange) * 1852.0 * 1.3
+			}
+
 			if isOwnshipTi {
 				if globalSettings.DEBUG {
 					log.Printf("Ownship target detected for code %X\n", ti.Icao_addr)

--- a/main/traffic.go
+++ b/main/traffic.go
@@ -370,7 +370,7 @@ func sendTrafficUpdates() {
 			// BUGBUG: Garmin Pilot can crash when more than 70 targets while using Synthetic Vision
 			// To work around this, until they fix it, restrict the size of targets to the radar range in the web UI
 			if globalSettings.LimitTraffic_Enabled {
-				shouldIgnore |= (ti.Distance > float64(globalSettings.RadarRange) * 1852.0 * 1.3)
+				shouldIgnore = shouldIgnore | (ti.Distance > float64(globalSettings.RadarRange) * 1852.0 * 1.3)
 			}
 
 			if isOwnshipTi {

--- a/main/traffic.go
+++ b/main/traffic.go
@@ -370,7 +370,7 @@ func sendTrafficUpdates() {
 			// BUGBUG: Garmin Pilot can crash when more than 70 targets while using Synthetic Vision
 			// To work around this, until they fix it, restrict the size of targets to the radar range in the web UI
 			if globalSettings.LimitTraffic_Enabled {
-				shouldIgnore = shouldIgnore | (ti.Distance > float64(globalSettings.RadarRange) * 1852.0 * 1.3)
+				shouldIgnore = shouldIgnore || (ti.Distance > float64(globalSettings.RadarRange) * 1852.0 * 1.3)
 			}
 
 			if isOwnshipTi {

--- a/main/traffic.go
+++ b/main/traffic.go
@@ -370,7 +370,7 @@ func sendTrafficUpdates() {
 			// BUGBUG: Garmin Pilot can crash when more than 70 targets while using Synthetic Vision
 			// To work around this, until they fix it, restrict the size of targets to the radar range in the web UI
 			if globalSettings.LimitTraffic_Enabled {
-				shouldIgnore |= ti.Distance > float64(globalSettings.RadarRange) * 1852.0 * 1.3
+				shouldIgnore |= (ti.Distance > float64(globalSettings.RadarRange) * 1852.0 * 1.3)
 			}
 
 			if isOwnshipTi {

--- a/notes/app-vendor-integration.md
+++ b/notes/app-vendor-integration.md
@@ -158,6 +158,7 @@ Stratux makes available a webserver to retrieve statistics which may be useful t
   "ES_Enabled": false,
   "Ping_Enabled": false,
   "Stratus_Enabled": false,
+  "LimitTraffic_Enabled": false,
   "FakeTrafficCount": 0,
   "GPS_Enabled": true,
   "BMP_Sensor_Enabled": true,

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -260,7 +260,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 
 	$scope.$parent.helppage = 'plates/settings-help.html';
 
-	var toggles = ['UAT_Enabled', 'ES_Enabled', 'OGN_Enabled', 'AIS_Enabled', 'Ping_Enabled', 'Stratus_Enabled', 'GPS_Enabled', 'IMU_Sensor_Enabled',
+	var toggles = ['UAT_Enabled', 'ES_Enabled', 'OGN_Enabled', 'AIS_Enabled', 'Ping_Enabled', 'Stratus_Enabled', 'LimitTraffic_Enabled', 'GPS_Enabled', 'IMU_Sensor_Enabled',
 		'BMP_Sensor_Enabled', 'DisplayTrafficSource', 'DEBUG', 'ReplayLog', 'AHRSLog', 'PersistentLogging', 'GDL90MSLAlt_Enabled', 'EstimateBearinglessDist', 'DarkMode'];
 
 	var settings = {};
@@ -298,6 +298,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 		$scope.AIS_Enabled = settings.AIS_Enabled;
 		$scope.Ping_Enabled = settings.Ping_Enabled;
 		$scope.Stratus_Enabled = settings.Stratus_Enabled;
+		$scope.LimitTraffic_Enabled = settings.LimitTraffic_Enabled;
 		$scope.FakeTrafficCount = settings.FakeTrafficCount;
 		$scope.GPS_Enabled = settings.GPS_Enabled;
 

--- a/web/plates/js/status.js
+++ b/web/plates/js/status.js
@@ -198,6 +198,7 @@ function StatusCtrl($rootScope, $scope, $state, $http, $interval, craftService) 
 			}
 
 			$scope.Stratus_Enabled = settings.Stratus_Enabled;
+			$scope.LimitTraffic_Enabled = settings.LimitTraffic_Enabled;
 			$scope.visible_gps = settings.GPS_Enabled;
 		}, function (response) {
 			// nop

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -216,6 +216,12 @@
                             <ui-switch ng-model='Stratus_Enabled' settings-change></ui-switch>
                         </div>
                     </div>
+                    <div class="form-group reset-flow">
+                        <label class="control-label col-xs-5">Limit traffic to set Radar Range</label>
+                        <div class="col-xs-7">
+                            <ui-switch ng-model='LimitTraffic_Enabled' settings-change></ui-switch>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
GP can crash while using Synthetic vision if to many ADS-B targets are sent to GP.  Turn on this switch limits to traffic to the radar range set in the web UI.